### PR TITLE
updating getDepthFrame function

### DIFF
--- a/src/KinectStreamsMat.cpp
+++ b/src/KinectStreamsMat.cpp
@@ -74,7 +74,7 @@ namespace K2OCV
 							depthImage = cv::Mat(frameHeight, frameWidth, CV_8U);
 							for (int i = 0; i < imgSize; i++) {
 								UINT16 depth = pixelData[i];
-								depthImage.at<UINT8>(i) = depth & 0xffff;
+								depthImage.at<UINT8>(i) = depth >> 5;
 							}
 						}
 						else if (SUCCEEDED(hr) && rawData) {


### PR DESCRIPTION
apply a right shift >> by 5 bits to convert from the UINT16 to UINT8 depth map will make the grayscale image smoother and much more pleasing for the eye.